### PR TITLE
Support only Laravel 11, 12, and 13

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,6 +46,7 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install dependencies
+        shell: bash
         run: |
           composer config --json policy.advisories.ignore '["laravel/framework"]'
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,12 +13,19 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.1]
-        laravel: [9.*]
+        php: [8.4, 8.3, 8.2]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
+          - laravel: 11.*
+            testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 13.*
+            php: 8.2 # Laravel 13 requires PHP >= 8.3
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -40,6 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          composer config --json policy.advisories.ignore '["laravel/framework"]'
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .phpunit.result.cache
+.phpunit.cache
 build
 composer.lock
 coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `pochocho/okta-saml-sso` will be documented in this file.
 
+## Unreleased
+
+### What's Changed
+
+- **Breaking:** Dropped support for Laravel 9 and 10. The package now requires Laravel 11, 12, or 13 and PHP >= 8.2 (PHP >= 8.3 for Laravel 13). The next release should be a major version bump.
+- Updated dev tooling: PHPUnit `^10.5|^11.5|^12.5`, orchestra/testbench `^9.0|^10.0|^11.0`, and widened PHPStan extension constraints.
+- Migrated `phpunit.xml` to the PHPUnit 10+ schema and replaced `@test`/`@define-env` docblock annotations with `#[Test]`/`#[DefineEnvironment]` attributes.
+
 ## v2.0.0 - 2024-07-27
 
 ### What's Changed

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,10 @@
     "name": "pochocho/okta-saml-sso",
     "description": "SSO for Laravel with Okta",
     "require": {
-        "php": "^8.1.0",
-        "illuminate/support": "9.*|10.*|11.*",
+        "php": "^8.2",
+        "illuminate/support": "^11.0|^12.0|^13.0",
         "litesaml/lightsaml": "^4.0",
-        "illuminate/auth": "9.*|10.*|11.*"
+        "illuminate/auth": "^11.0|^12.0|^13.0"
     },
     "license": "MIT",
     "autoload": {
@@ -37,12 +37,12 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "orchestra/testbench": "^v8.24.0",
+        "phpunit/phpunit": "^10.5|^11.5|^12.5",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "laravel/pint": "^1.17",
-        "phpstan/phpstan-phpunit": "^1.3",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/extension-installer": "^1.2"
+        "phpstan/phpstan-phpunit": "^1.3|^2.0",
+        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+        "phpstan/extension-installer": "^1.2|^2.0"
     },
     "config": {
         "allow-plugins": {

--- a/config/okta-saml-sso.php
+++ b/config/okta-saml-sso.php
@@ -1,5 +1,7 @@
 <?php
 
+use Pochocho\OktaSamlSso\Actions\SamlUserAuthenticated;
+
 return [
 
     'attribute_statements' => explode(
@@ -20,7 +22,7 @@ return [
 
     'authenticatable_model' => env('OKTA_AUTHENTICATABLE_MODEL', "App\Models\User"),
 
-    'authenticate_action' => Pochocho\OktaSamlSso\Actions\SamlUserAuthenticated::class,
+    'authenticate_action' => SamlUserAuthenticated::class,
 
     'login_redirect_route' => env('LOGIN_REDIRECT_ROUTE'),
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,4 +7,3 @@ parameters:
         - src
         - config
     tmpDir: build/phpstan
-    checkMissingIterableValueType: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Http/Middleware/SsoAuthenticate.php
+++ b/src/Http/Middleware/SsoAuthenticate.php
@@ -3,13 +3,14 @@
 namespace Pochocho\OktaSamlSso\Http\Middleware;
 
 use Illuminate\Auth\Middleware\Authenticate as AuthenticateMiddleware;
+use Illuminate\Http\Request;
 
 class SsoAuthenticate extends AuthenticateMiddleware
 {
     /**
      * Get the path the user should be redirected to when they are not authenticated.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return string|null
      */
     protected function redirectTo($request)

--- a/src/OktaDeserializer.php
+++ b/src/OktaDeserializer.php
@@ -7,13 +7,14 @@ use LightSaml\Credential\X509Certificate;
 use LightSaml\Credential\X509Credential;
 use LightSaml\Error\LightSamlSecurityException;
 use LightSaml\Model\Assertion\Conditions;
+use LightSaml\Model\Assertion\EncryptedAssertionReader;
 use LightSaml\Model\Context\DeserializationContext;
 use LightSaml\Model\Protocol\Response;
 use LightSaml\Model\XmlDSig\SignatureXmlReader;
 
 class OktaDeserializer
 {
-    private ?X509Credential $credentials;
+    private ?X509Credential $credentials = null;
 
     public function __construct(
         private DeserializationContext $deserializationContext,
@@ -83,7 +84,7 @@ class OktaDeserializer
     private function decryptAssertions()
     {
         $decryptDeserializeContext = new DeserializationContext;
-        /** @var \LightSaml\Model\Assertion\EncryptedAssertionReader $reader */
+        /** @var EncryptedAssertionReader $reader */
         $reader = $this->response->getFirstEncryptedAssertion();
 
         return $reader->decryptMultiAssertion([$this->credentials], $decryptDeserializeContext);

--- a/tests/OktaEntityTest.php
+++ b/tests/OktaEntityTest.php
@@ -4,7 +4,9 @@ namespace Pochocho\OktaSamlSso\Tests;
 
 use Exception;
 use LightSaml\Model\Assertion\Attribute;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Pochocho\OktaSamlSso\OktaEntity;
 use Pochocho\OktaSamlSso\OktaSamlSsoServiceProvider;
 
@@ -53,12 +55,9 @@ class OktaEntityTest extends TestCase
         return $samlAttributes;
     }
 
-    /**
-     * @test
-     *
-     * @define-env limitedAttributeStatements
-     */
-    public function itFailsToFillIfUnexpectedAttributes()
+    #[Test]
+    #[DefineEnvironment('limitedAttributeStatements')]
+    public function it_fails_to_fill_if_unexpected_attributes()
     {
         $oktaEntity = app()->make(OktaEntity::class);
 
@@ -71,10 +70,8 @@ class OktaEntityTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function itFillsIfAllAttributesConfirgured()
+    #[Test]
+    public function it_fills_if_all_attributes_confirgured()
     {
         $oktaEntity = app()->make(OktaEntity::class);
 
@@ -90,10 +87,8 @@ class OktaEntityTest extends TestCase
         $this->assertNotNull($oktaEntity->groups);
     }
 
-    /**
-     * @test
-     */
-    public function itTreatsUnspecifiedFormatsToArrays()
+    #[Test]
+    public function it_treats_unspecified_formats_to_arrays()
     {
         $oktaEntity = app()->make(OktaEntity::class);
 
@@ -106,10 +101,8 @@ class OktaEntityTest extends TestCase
         $this->assertIsArray($oktaEntity->groups);
     }
 
-    /**
-     * @test
-     */
-    public function itTreatsBasicFormatsAsStrings()
+    #[Test]
+    public function it_treats_basic_formats_as_strings()
     {
         $oktaEntity = app()->make(OktaEntity::class);
 

--- a/tests/OktaWebhooksTest.php
+++ b/tests/OktaWebhooksTest.php
@@ -3,7 +3,9 @@
 namespace Pochocho\OktaSamlSso\Tests;
 
 use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Pochocho\OktaSamlSso\Events\OktaWebhookReceived;
 use Pochocho\OktaSamlSso\OktaSamlSsoServiceProvider;
 
@@ -22,12 +24,9 @@ class OktaWebhooksTest extends TestCase
         $app->config->set('okta-saml-sso.webhooks.authorization.secret', '12345678');
     }
 
-    /**
-     * @test
-     *
-     * @define-env webhookEnabledSettings
-     */
-    public function itCanVerifyOwnershipOfServer()
+    #[Test]
+    #[DefineEnvironment('webhookEnabledSettings')]
+    public function it_can_verify_ownership_of_server()
     {
         $verifierCode = '🌯';
 
@@ -44,12 +43,9 @@ class OktaWebhooksTest extends TestCase
         $this->assertEquals($verifierCode, $response->json('verification'));
     }
 
-    /**
-     * @test
-     *
-     * @define-env webhookEnabledSettings
-     */
-    public function itCanProtectsVerificationAndProcessingEndpointsWithSecret()
+    #[Test]
+    #[DefineEnvironment('webhookEnabledSettings')]
+    public function it_can_protects_verification_and_processing_endpoints_with_secret()
     {
         $validSecretCode = '12345678';
         $invalidSecret = 'naughty';
@@ -93,12 +89,9 @@ class OktaWebhooksTest extends TestCase
         $response->assertOk();
     }
 
-    /**
-     * @test
-     *
-     * @define-env webhookEnabledSettings
-     */
-    public function itFiresEventToProcessWebhooks()
+    #[Test]
+    #[DefineEnvironment('webhookEnabledSettings')]
+    public function it_fires_event_to_process_webhooks()
     {
         Event::fake();
 


### PR DESCRIPTION
## Summary

- **Breaking:** drops Laravel 9/10 support; requires Laravel 11, 12, or 13 and PHP >= 8.2 (>= 8.3 for Laravel 13). Next release should be a major version bump.
- Updates dev tooling: PHPUnit `^10.5|^11.5|^12.5`, orchestra/testbench `^9.0|^10.0|^11.0`, widened PHPStan extension constraints for PHPStan 2.x.
- Migrates `phpunit.xml` to the PHPUnit 10+ schema and replaces `@test`/`@define-env` docblock annotations with `#[Test]`/`#[DefineEnvironment]` attributes (docblock metadata was removed in PHPUnit 12).
- CI matrix now covers PHP 8.2/8.3/8.4 × Laravel 11/12/13 × prefer-lowest/prefer-stable on Ubuntu and Windows, excluding Laravel 13 on PHP 8.2. The install step ignores composer security-advisory blocking for `laravel/framework` only, so EOL'd Laravel 11 releases remain installable in the test matrix.
- Replaces the removed `checkMissingIterableValueType` PHPStan option (a no-op at level 4) and initializes `OktaDeserializer::$credentials` to `null` to satisfy PHPStan 2.x.

## Test plan

- [x] `composer update` resolves on PHP 8.3 (Laravel 13 / testbench 11 / PHPUnit 12.5)
- [x] `composer test` — 7 tests, 17 assertions pass
- [x] `composer analyze` — PHPStan clean, existing baseline still valid
- [x] Local matrix simulation: L11+tb9 (lowest: framework 11.0.3 / PHPUnit 10.5; stable: 11.54.0 / PHPUnit 12.5), L12+tb10 lowest (12.0.1 / PHPUnit 11.5), L13+tb11 lowest (13.0.0 / PHPUnit 11.5) — all green
- [x] CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)